### PR TITLE
Add methods to get data for specific dates

### DIFF
--- a/openeihttp/__init__.py
+++ b/openeihttp/__init__.py
@@ -190,6 +190,7 @@ class Rates:
         self.adjustment(datetime.datetime.today())
 
     def adjustment(self, date) -> float | None:
+        """Return the rate for a specific date."""
         assert self._data is not None
         if "energyratestructure" in self._data:
             adj = None
@@ -298,7 +299,7 @@ class Rates:
         self.demand_adjustment(datetime.datetime.today())
 
     def demand_adjustment(self, date) -> float | None:
-        """Return the current rate."""
+        """Return the rate for a specific date."""
         assert self._data is not None
         if "demandratestructure" in self._data:
             adj = None

--- a/openeihttp/__init__.py
+++ b/openeihttp/__init__.py
@@ -156,13 +156,16 @@ class Rates:
     @property
     def current_rate(self) -> float | None:
         """Return the current rate."""
+        self.rate(datetime.datetime.today())
+
+    def rate(self, date) -> float | None:
+        """Return the rate for a specific date."""
         assert self._data is not None
         if "energyratestructure" in self._data:
             weekend = False
-            now = datetime.datetime.today()
-            month = now.month - 1
-            hour = now.hour
-            if now.weekday() > 4:
+            month = date.month - 1
+            hour = date.hour
+            if date.weekday() > 4:
                 weekend = True
             table = "energyweekdayschedule"
             if weekend:
@@ -184,14 +187,16 @@ class Rates:
     @property
     def current_adjustment(self) -> float | None:
         """Return the current rate."""
+        self.adjustment(datetime.datetime.today())
+
+    def adjustment(self, date) -> float | None:
         assert self._data is not None
         if "energyratestructure" in self._data:
             adj = None
             weekend = False
-            now = datetime.datetime.today()
-            month = now.month - 1
-            hour = now.hour
-            if now.weekday() > 4:
+            month = date.month - 1
+            hour = date.hour
+            if date.weekday() > 4:
                 weekend = True
             table = "energyweekdayschedule"
             if weekend:
@@ -214,13 +219,20 @@ class Rates:
 
         Requires the monthy accumulative meter reading.
         """
+        self.tier_rate_for_month(datetime.datetime.today())
+
+
+    def tier_rate_for_month(self, date) -> float | None:
+        """Return tier rate for a specific month.
+
+        Requires the monthy accumulative meter reading.
+        """
         assert self._data is not None
         if "energyratestructure" in self._data:
             weekend = False
-            now = datetime.datetime.today()
-            month = now.month - 1
-            hour = now.hour
-            if now.weekday() > 4:
+            month = date.month - 1
+            hour = date.hour
+            if date.weekday() > 4:
                 weekend = True
             table = "energyweekdayschedule"
             if weekend:
@@ -257,13 +269,16 @@ class Rates:
     @property
     def current_demand_rate(self) -> float | None:
         """Return the current rate."""
+        self.demand_rate(self, datetime.datetime.today())
+
+    def demand_rate(self, date) -> float | None:
+        """Return the rate for a specific date."""
         assert self._data is not None
         if "demandratestructure" in self._data:
             weekend = False
-            now = datetime.datetime.today()
-            month = now.month - 1
-            hour = now.hour
-            if now.weekday() > 4:
+            month = date.month - 1
+            hour = date.hour
+            if date.weekday() > 4:
                 weekend = True
             table = "demandweekdayschedule"
             if weekend:
@@ -280,14 +295,17 @@ class Rates:
     @property
     def current_demand_adjustment(self) -> float | None:
         """Return the current rate."""
+        self.demand_adjustment(datetime.datetime.today())
+
+    def demand_adjustment(self, date) -> float | None:
+        """Return the current rate."""
         assert self._data is not None
         if "demandratestructure" in self._data:
             adj = None
             weekend = False
-            now = datetime.datetime.today()
-            month = now.month - 1
-            hour = now.hour
-            if now.weekday() > 4:
+            month = date.month - 1
+            hour = date.hour
+            if date.weekday() > 4:
                 weekend = True
             table = "demandweekdayschedule"
             if weekend:

--- a/openeihttp/__init__.py
+++ b/openeihttp/__init__.py
@@ -156,7 +156,7 @@ class Rates:
     @property
     def current_rate(self) -> float | None:
         """Return the current rate."""
-        self.rate(datetime.datetime.today())
+        return self.rate(datetime.datetime.today())
 
     def rate(self, date) -> float | None:
         """Return the rate for a specific date."""
@@ -187,7 +187,7 @@ class Rates:
     @property
     def current_adjustment(self) -> float | None:
         """Return the current rate."""
-        self.adjustment(datetime.datetime.today())
+        return self.adjustment(datetime.datetime.today())
 
     def adjustment(self, date) -> float | None:
         """Return the rate for a specific date."""
@@ -220,8 +220,7 @@ class Rates:
 
         Requires the monthy accumulative meter reading.
         """
-        self.tier_rate_for_month(datetime.datetime.today())
-
+        return self.tier_rate_for_month(datetime.datetime.today())
 
     def tier_rate_for_month(self, date) -> float | None:
         """Return tier rate for a specific month.
@@ -270,7 +269,7 @@ class Rates:
     @property
     def current_demand_rate(self) -> float | None:
         """Return the current rate."""
-        self.demand_rate(self, datetime.datetime.today())
+        return self.demand_rate(datetime.datetime.today())
 
     def demand_rate(self, date) -> float | None:
         """Return the rate for a specific date."""
@@ -296,7 +295,7 @@ class Rates:
     @property
     def current_demand_adjustment(self) -> float | None:
         """Return the current rate."""
-        self.demand_adjustment(datetime.datetime.today())
+        return self.demand_adjustment(datetime.datetime.today())
 
     def demand_adjustment(self, date) -> float | None:
         """Return the rate for a specific date."""


### PR DESCRIPTION
I'm using your awesome ha-openei integration for realtime monitoring. I wanted to use the OpenEI data to analyze some of my historical utility data, but in order to do that I needed to break out methods to be able to get some rates for specific datetimes instead of always having `now`