### PR TITLE
feat: add rate structure property

### DIFF
--- a/openeihttp/__init__.py
+++ b/openeihttp/__init__.py
@@ -156,6 +156,30 @@ class Rates:
             _LOGGER.debug("Data updated, results: %s", self._data)
 
     @property
+    def current_energy_rate_structure(self) -> int | None:
+        """Return the current rate structure."""
+        return self.rate_structure(datetime.datetime.today(), "energy")
+
+    def rate_structure(self, date, rate_type) -> int | None:
+        """Return the rate structure for a specific date."""
+        assert self._data is not None
+        if f"{rate_type}ratestructure" in self._data:
+            month = date.month - 1
+            hour = date.hour
+            weekend = date.weekday() > 4
+
+            table = (
+                f"{rate_type}weekendschedule"
+                if weekend
+                else f"{rate_type}weekdayschedule"
+            )
+            lookup_table = self._data[table]
+            rate_structure = lookup_table[month][hour]
+
+            return rate_structure
+        return None
+
+    @property
     def current_rate(self) -> float | None:
         """Return the current rate."""
         return self.rate(datetime.datetime.today())
@@ -163,17 +187,8 @@ class Rates:
     def rate(self, date) -> float | None:
         """Return the rate for a specific date."""
         assert self._data is not None
-        if "energyratestructure" in self._data:
-            weekend = False
-            month = date.month - 1
-            hour = date.hour
-            if date.weekday() > 4:
-                weekend = True
-            table = "energyweekdayschedule"
-            if weekend:
-                table = "energyweekendschedule"
-            lookup_table = self._data[table]
-            rate_structure = lookup_table[month][hour]
+        rate_structure = self.rate_structure(date, "energy")
+        if rate_structure is not None:
             if self._reading:
                 value = float(self._reading)
                 rate_data = self._data["energyratestructure"][rate_structure]
@@ -194,18 +209,9 @@ class Rates:
     def adjustment(self, date) -> float | None:
         """Return the rate for a specific date."""
         assert self._data is not None
-        if "energyratestructure" in self._data:
+        rate_structure = self.rate_structure(date, "energy")
+        if rate_structure is not None:
             adj = None
-            weekend = False
-            month = date.month - 1
-            hour = date.hour
-            if date.weekday() > 4:
-                weekend = True
-            table = "energyweekdayschedule"
-            if weekend:
-                table = "energyweekendschedule"
-            lookup_table = self._data[table]
-            rate_structure = lookup_table[month][hour]
             if self._reading:
                 rate_data = self._data["energyratestructure"][rate_structure]
                 if "adj" in rate_data[-1]:
@@ -230,17 +236,8 @@ class Rates:
         Requires the monthy accumulative meter reading.
         """
         assert self._data is not None
-        if "energyratestructure" in self._data:
-            weekend = False
-            month = date.month - 1
-            hour = date.hour
-            if date.weekday() > 4:
-                weekend = True
-            table = "energyweekdayschedule"
-            if weekend:
-                table = "energyweekendschedule"
-            lookup_table = self._data[table]
-            rate_structure = lookup_table[month][hour]
+        rate_structure = self.rate_structure(date, "energy")
+        if rate_structure is not None:
             if self._reading:
                 value = float(self._reading)
                 rate_data = self._data["energyratestructure"][rate_structure]
@@ -276,21 +273,9 @@ class Rates:
     def demand_rate(self, date) -> float | None:
         """Return the rate for a specific date."""
         assert self._data is not None
-        if "demandratestructure" in self._data:
-            weekend = False
-            month = date.month - 1
-            hour = date.hour
-            if date.weekday() > 4:
-                weekend = True
-            table = "demandweekdayschedule"
-            if weekend:
-                table = "demandweekendschedule"
-
-            lookup_table = self._data[table]
-            rate_structure = lookup_table[month][hour]
-
+        rate_structure = self.rate_structure(date, "demand")
+        if rate_structure is not None:
             rate = self._data["demandratestructure"][rate_structure][0]["rate"]
-
             return rate
         return None
 
@@ -302,19 +287,9 @@ class Rates:
     def demand_adjustment(self, date) -> float | None:
         """Return the rate for a specific date."""
         assert self._data is not None
-        if "demandratestructure" in self._data:
+        rate_structure = self.rate_structure(date, "demand")
+        if rate_structure is not None:
             adj = None
-            weekend = False
-            month = date.month - 1
-            hour = date.hour
-            if date.weekday() > 4:
-                weekend = True
-            table = "demandweekdayschedule"
-            if weekend:
-                table = "demandweekendschedule"
-
-            lookup_table = self._data[table]
-            rate_structure = lookup_table[month][hour]
 
             adj_data = self._data["demandratestructure"][rate_structure][0]
             if "adj" in adj_data:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -663,8 +663,22 @@ def test_get_lookup_data_radius(test_lookup_radius, lookup_mock_radius, caplog):
 def test_get_tier_rate_data_low(test_lookup_tier_low, tier_plandata_mock):
     """Test rate schedules."""
     test_lookup_tier_low.update()
-    status = test_lookup_tier_low.current_rate
-    assert status == 0.25902
+    rate = test_lookup_tier_low.current_rate
+    struture = test_lookup_tier_low.current_energy_rate_structure
+    assert rate == 0.25902
+    assert struture == 0
+
+
+@freeze_time(
+    "2021-11-01 10:21:34"
+)  # November 1 is the first day of a separate rate structure for this plan
+def test_get_tier_rate_data_low_second_period(test_lookup_tier_low, tier_plandata_mock):
+    """Test rate schedules."""
+    test_lookup_tier_low.update()
+    rate = test_lookup_tier_low.current_rate
+    structure = test_lookup_tier_low.current_energy_rate_structure
+    assert rate == 0.25902
+    assert structure == 1
 
 
 @freeze_time("2021-08-13 10:21:34")


### PR DESCRIPTION
I have a gnarly template in my home assistant config to reverse-calculate the rate name from the current cost, which is kind of a bummer because Jinja floats absolutely suck. 

```Jinja
{% set rates = state_attr('sensor.san_diego_gas_electric_co_current_energy_rate', 'all_rates') | map('round', 3) | list %}
{% set current = states('sensor.san_diego_gas_electric_co_current_energy_rate') | round(3) %}
{% set i = rates.index(current) %}
{% set d = {
  0: "on peak",
  1: "off peak",
  2: "super off peak",
  3: "on peak",
  4: "off peak",
  5: "super off peak",
} %}

{{ d.get(i) }}
```

While I'm sure this template could be better (I'm no Jinja master), I can't see any way around the gross `map('round', 3)` call except to expose the index of the selected rate structure. [SDG&E's EV-TOU-2](https://www.sdge.com/residential/pricing-plans/about-our-pricing-plans/electric-vehicle-plans#DR2) plan has both Summer and Winter periods for On, Off, and Super Off Peak periods.

This PR exposes the current rate index so I can cut everything except the dictionary. (I'll create a pull request for the firstof9/ha-openei repo after this is merged.)

