### PR TITLE
feat: add next rate structure (and time) property

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -883,6 +883,171 @@ async def test_get_tier_rate_data_low_second_period(
     assert structure == 1
 
 
+@freeze_time("2025-01-01 10:21:34")
+async def test_get_next_rate_structure(mock_aioclient):
+    """
+    Test calculating the next rate structure
+    This test is run on a weekday with the new structure occuring the same day
+    """
+    mock_aioclient.get(
+        re.compile(TEST_PATTERN),
+        status=200,
+        body=load_fixture("plan_data.json"),
+    )
+    test_rates = openeihttp.Rates(
+        api="fakeAPIKey", lat="1", lon="1", plan="574613aa5457a3557e906f5b"
+    )
+
+    await test_rates.clear_cache()
+    await test_rates.update()
+
+    current_structure = test_rates.current_energy_rate_structure
+    assert current_structure == 3
+
+    next_struture = test_rates.next_energy_rate_structure
+    next_time = test_rates.next_energy_rate_structure_time
+    assert next_struture == 2
+    assert next_time == datetime.datetime(2025, 1, 1, 12, 0)
+
+
+@freeze_time("2025-01-01 23:21:34") 
+async def test_get_next_rate_structure_next_day(mock_aioclient):
+    """
+    Test calculating the next rate structure
+    This test is run on a weekday with the new structure occuring the next day (also a weekday)
+    """
+    mock_aioclient.get(
+        re.compile(TEST_PATTERN),
+        status=200,
+        body=load_fixture("plan_data.json"),
+    )
+    test_rates = openeihttp.Rates(
+        api="fakeAPIKey", lat="1", lon="1", plan="574613aa5457a3557e906f5b"
+    )
+
+    await test_rates.clear_cache()
+    await test_rates.update()
+
+    current_structure = test_rates.current_energy_rate_structure
+    assert current_structure == 3
+
+    next_struture = test_rates.next_energy_rate_structure
+    next_time = test_rates.next_energy_rate_structure_time
+    assert next_struture == 2
+    assert next_time == datetime.datetime(2025, 1, 2, 12, 0)
+    
+
+@freeze_time("2025-01-03 23:21:34")
+async def test_get_next_rate_structure_weekend_loop(mock_aioclient):
+    """
+    Test calculating the next rate structure
+    This test is run on a weekday. The following weekend has the same structure for the entire week
+    So we must loop back to the following weekday to find the next structure
+    """
+    mock_aioclient.get(
+        re.compile(TEST_PATTERN),
+        status=200,
+        body=load_fixture("plan_data.json"),
+    )
+    test_rates = openeihttp.Rates(
+        api="fakeAPIKey", lat="1", lon="1", plan="574613aa5457a3557e906f5b"
+    )
+
+    await test_rates.clear_cache()
+    await test_rates.update()
+
+    current_structure = test_rates.current_energy_rate_structure
+    assert current_structure == 3
+
+    next_struture = test_rates.next_energy_rate_structure
+    next_time = test_rates.next_energy_rate_structure_time
+    assert next_struture == 2
+    assert next_time == datetime.datetime(2025, 1, 6, 12, 0)
+
+
+@freeze_time("2025-01-03 23:21:34")
+async def test_get_next_rate_structure_next_month(mock_aioclient):
+    """
+    Test calculating the next rate structure
+    plan_tier_data has a different structure than plan_data and the structure doesn't change until May
+    """
+    mock_aioclient.get(
+        re.compile(TEST_PATTERN),
+        status=200,
+        body=load_fixture("plan_tier_data.json"),
+    )
+    test_rates = openeihttp.Rates(
+        api="fakeAPIKey", lat="1", lon="1", plan="574613aa5457a3557e906f5b"
+    )
+
+    await test_rates.clear_cache()
+    await test_rates.update()
+
+    current_structure = test_rates.current_energy_rate_structure
+    assert current_structure == 1
+
+    next_struture = test_rates.next_energy_rate_structure
+    next_time = test_rates.next_energy_rate_structure_time
+    assert next_struture == 0
+    assert next_time == datetime.datetime(2025, 5, 1, 0, 0)
+
+
+@freeze_time("2025-01-04 23:21:34")
+async def test_get_next_rate_structure_next_month_weekend_start(mock_aioclient):
+    """
+    Test calculating the next rate structure
+    This test is run on a weekend. The following weekday has the same structure for the entire week
+    The structure doesn't change until May
+    """
+    mock_aioclient.get(
+        re.compile(TEST_PATTERN),
+        status=200,
+        body=load_fixture("plan_tier_data.json"),
+    )
+    test_rates = openeihttp.Rates(
+        api="fakeAPIKey", lat="1", lon="1", plan="574613aa5457a3557e906f5b"
+    )
+
+    await test_rates.clear_cache()
+    await test_rates.update()
+
+    current_structure = test_rates.current_energy_rate_structure
+    assert current_structure == 1
+
+    next_struture = test_rates.next_energy_rate_structure
+    next_time = test_rates.next_energy_rate_structure_time
+    assert next_struture == 0
+    assert next_time == datetime.datetime(2025, 5, 1, 0, 0)    
+
+
+@freeze_time("2024-11-01 23:21:34")
+async def test_get_next_rate_structure_next_year(mock_aioclient):
+    """
+    Test calculating the next rate structure
+    This test is run on a weekday. The following weekend has the same structure for the entire week
+    The structure doesn't change until May of the following year
+    """
+    mock_aioclient.get(
+        re.compile(TEST_PATTERN),
+        status=200,
+        body=load_fixture("plan_tier_data.json"),
+    )
+    test_rates = openeihttp.Rates(
+        api="fakeAPIKey", lat="1", lon="1", plan="574613aa5457a3557e906f5b"
+    )
+
+    await test_rates.clear_cache()
+    await test_rates.update()
+
+    current_structure = test_rates.current_energy_rate_structure
+    assert current_structure == 1
+
+    next_struture = test_rates.next_energy_rate_structure
+    next_time = test_rates.next_energy_rate_structure_time
+    assert next_struture == 0
+    assert next_time == datetime.datetime(2025, 5, 1, 0, 0)    
+
+
 @freeze_time("2021-08-13 10:21:34")
 async def test_get_tier_rate_data_med(test_lookup_tier_med, mock_aioclient):
     """Test rate schedules."""


### PR DESCRIPTION
I have the next rate structures for my TOU plan hardcoded into a Home Assistant template in a pretty ugly way. I want to be able to easily know the next rate structure (and when it will happen) so I can automatically perform operations like preconditioning the AC.

This PR performs a optimized calculation to determine when the next rate structure will be. A naive approach to this probably would loop through ever hour of every day for the next year. However, since rates can only change between hours and between weekdays / weekends, this can be heavily optimized to only check ~2 days per month.

The basic concept is, looping through each month:
- check the rest of today (or the start of a new month)
- check the next day if we are still in the same month and same type of day (weekday / weekend)
- find when the next weekend / weekday starts and check that day

Python is not a language I really ever use so please let me know if I am breaking some unknown Python style or best practices 😄 

Also, it would be nice to return both the structure int and time in the same call, but `ha-openei` expects any tuples returned to have the second value be the unit of measure. Let me know if you want to adjust this!