### PR TITLE
fix: handle end of year properly for next_rate_schedule

### DIFF
--- a/openeihttp/__init__.py
+++ b/openeihttp/__init__.py
@@ -266,7 +266,7 @@ class Rates:
     ) -> tuple[datetime.datetime | None, int | None]:
         """Return the next datetime at which the rate structure changes."""
         assert self._data is not None
-        if not f"{rate_type}ratestructure" in self._data:
+        if f"{rate_type}ratestructure" not in self._data:
             return None, None
 
         current_structure = self.rate_structure(start, rate_type)

--- a/openeihttp/__init__.py
+++ b/openeihttp/__init__.py
@@ -264,18 +264,14 @@ class Rates:
     def next_rate_schedule(
         self, start: datetime.datetime, rate_type: str
     ) -> tuple[datetime.datetime | None, int | None]:
-        """
-        Return the next datetime at which the rate structure changes and the new rate structure.
-
-        This function is optimzied to avoid looping over every hour, day, month combination.
-        """
+        """Return the next datetime at which the rate structure changes."""
         assert self._data is not None
         if not f"{rate_type}ratestructure" in self._data:
             return None, None
 
         current_structure = self.rate_structure(start, rate_type)
         current_time = start
-        # Loop through the next 12 months
+
         for month_idx in range(start.month - 1, 12 + start.month - 1):
             current_time = current_time.replace(
                 year=start.year + (month_idx // 12),
@@ -291,10 +287,7 @@ class Rates:
                 if day_of_week > 4
                 else ["weekdayschedule", "weekendschedule"]
             )
-            # If the hour is greater than 0 (only the first month),
-            # a case can occur where the next rate is earlier in the same schedule
-            # This requires checking the first schedule again if there is no change found
-            # in the latter part of the first schedule or the second schedule.
+
             if current_time.hour > 0:
                 schedules.append(schedules[0])
 
@@ -305,37 +298,38 @@ class Rates:
                 for hour in range(current_time.hour, 24 + current_time.hour):
                     hour = hour % 24
                     rate_structure = self._data[table][current_time.month - 1][hour]
-                    if rate_structure != current_structure:
-                        # hour < currnet_time.hour indicates we are in the next day
-                        # Check to make sure the schedule type hasn't changed and we
-                        # are in the same month.
-                        if hour < current_time.hour and day_of_week not in [4, 6]:
-                            if (
-                                current_time + datetime.timedelta(days=1)
-                            ).month == current_time.month:
-                                return (
-                                    current_time.replace(
-                                        day=current_time.day + 1, hour=hour
-                                    ),
-                                    rate_structure,
-                                )
-                        elif hour >= current_time.hour:
-                            return current_time.replace(hour=hour), rate_structure
 
-                # Move to the day where the next schedule starts
+                    if rate_structure == current_structure:
+                        continue
+
+                    if hour >= current_time.hour:
+                        return current_time.replace(hour=hour), rate_structure
+
+                    # Handle next day transition
+                    if day_of_week not in [4, 6]:
+                        if (
+                            current_time + datetime.timedelta(days=1)
+                        ).month == current_time.month:
+                            return (
+                                current_time.replace(
+                                    day=current_time.day + 1, hour=hour
+                                ),
+                                rate_structure,
+                            )
+
                 days_to_move = 5 - day_of_week if day_of_week <= 4 else 7 - day_of_week
+
                 if (
                     current_time + datetime.timedelta(days=days_to_move)
-                ).month > current_time.month:
+                ).month != current_time.month:
                     break
+
                 current_time = current_time.replace(
                     hour=0, day=current_time.day + days_to_move
                 )
 
             current_time = current_time.replace(day=1)
 
-        # If we reach here, it means we didn't find a change in the next 12 months
-        # Assume the rate structure doesn't change
         return None, current_structure
 
     @property

--- a/openeihttp/cache.py
+++ b/openeihttp/cache.py
@@ -1,4 +1,4 @@
-""" Cache functions for python-openei."""
+"""Cache functions for python-openei."""
 
 import json
 import logging

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.2.7"
+VERSION = "0.2.8"
 
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -40,4 +40,4 @@ deps =
   -rrequirements_lint.txt
 
 [flake8]
-max-line-length = 88
+max-line-length = 100


### PR DESCRIPTION
Related to https://github.com/firstof9/ha-openei/issues/96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined rate schedule calculation logic for clearer, more maintainable behavior without changing public interfaces

* **Style**
  * Minor docstring and formatting cleanups

* **Chores**
  * Package version bumped to 0.2.8
  * Development lint/config updated (line-length relaxed)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->